### PR TITLE
query: Fix favorite query error

### DIFF
--- a/gnomemusic/query.py
+++ b/gnomemusic/query.py
@@ -829,7 +829,7 @@ class Query():
         ?as nie:url ?url .
         FILTER (
           tracker:uri-is-descendant(
-            '%(music_dir)s', nie:url(?as)
+            '%(music_dir)s', ?url
           )
         )
     } ORDER BY DESC(tracker:added(?song))


### PR DESCRIPTION
Hi guys,

I've recently experienced the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/gnomemusic/playlists.py", line 139, in callback
    self.update_static_playlist(playlist)
  File "/usr/lib/python3.5/site-packages/gnomemusic/playlists.py", line 176, in update_static_playlist
    while cursor.next():
GLib.Error: tracker-db-interface-error-quark: Invalid child (0)
```
I've investigated this a little bit and figured out that it's related to the get_favorite_songs() method.
It seems that this minor change fixes the issue.

Please feel free to merge if you consider this valid.