### PR TITLE
Avoid adding duplicate albums in albums view

### DIFF
--- a/gnomemusic/views/albumsview.py
+++ b/gnomemusic/views/albumsview.py
@@ -47,6 +47,7 @@ class AlbumsView(BaseView):
         self.add(self._albumWidget)
         self.albums_selected = []
         self.all_items = []
+        self.all_album_ids = []
         self.items_selected = []
         self.items_selected_callback = None
         self._add_list_renderers()
@@ -141,7 +142,15 @@ class AlbumsView(BaseView):
 
     @log
     def _add_item(self, source, param, item, remaining=0, data=None):
+        should_add = False
+
         if item:
+            album_id = [utils.get_artist_name(item), utils.get_media_title(item)]
+            should_add = not album_id in self.all_album_ids
+
+        if should_add:
+            #print("Adding new item ", album_id)
+            self.all_album_ids.append(album_id)
             # Store all items to optimize 'Select All' action
             self.all_items.append(item)
 


### PR DESCRIPTION
Gnome Music would show duplicate (or even multiple) entries for the same album (only in albums view, the rest are fine). The problem happens under Ubuntu 17.10, but it wasn't an issue with tracker (running "tracker search --music-albums" only showed each album once). Not sure if the fix is clean enough, not sure if it happens on other systems.

EDIT: If needed, I can give more information, screenshots, etc