### PR TITLE
Proposed solution to  issue #165 Tracker error dialog

### DIFF
--- a/gnomemusic/__init__.py
+++ b/gnomemusic/__init__.py
@@ -28,9 +28,12 @@
 from itertools import chain
 from time import time
 import logging
-
+from gnomemusic.errordialog import ErrorDialog
 import gi
-gi.require_version('Tracker', '2.0')
+try:
+    gi.require_version('Tracker', '2.0')
+except:
+    ErrorDialog(('Tracker','2.0'))
 from gi.repository import Tracker
 
 logger = logging.getLogger(__name__)

--- a/gnomemusic/errordialog.py
+++ b/gnomemusic/errordialog.py
@@ -1,0 +1,13 @@
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+import sys
+
+class ErrorDialog():
+    def __init__(self,err_msg):
+        dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK, "%s not found" % (err_msg[0]))
+        dialog.format_secondary_text("%s is either missing or you have version other than \'%s\'\nplease install it using \"sudo apt install %s\"" % (err_msg[0],err_msg[1],err_msg[0].lower()))
+        dialog.run()
+        dialog.destroy()
+        sys.exit(1)


### PR DESCRIPTION
As per [#165](https://gitlab.gnome.org/GNOME/gnome-music/issues/165) by @albfan Music application is dependent on tracker and therefore its absence shall be notified to the user via an error dialog and exit the application if dependencies are not met.