### PR TITLE
Optimize SVG icons

### DIFF
--- a/data/icons/hicolor/scalable/apps/org.gnome.Music.svg
+++ b/data/icons/hicolor/scalable/apps/org.gnome.Music.svg
@@ -1,224 +1,82 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 128 128"
-   style="display:inline;enable-background:new"
-   version="1.0"
-   id="svg11300"
-   height="128"
-   width="128">
-  <title
-     id="title4162">Adwaita Icon Template</title>
-  <defs
-     id="defs3">
-    <linearGradient
-       id="linearGradient1093">
-      <stop
-         id="stop1089"
-         offset="0"
-         style="stop-color:#f6d32d;stop-opacity:1" />
-      <stop
-         id="stop1091"
-         offset="1"
-         style="stop-color:#f9f06b;stop-opacity:1" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg enable-background="new" version="1.0" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Adwaita Icon Template</title>
+  <defs>
+    <radialGradient id="radialGradient1073" cx="280" cy="16.275" r="160" gradientTransform="matrix(1 0 0 1.1759 0 -118.64)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c4a000" offset="0"/>
+      <stop stop-color="#edd400" stop-opacity="0" offset="1"/>
+    </radialGradient>
+    <radialGradient id="radialGradient1075" cx="265.28" cy="65.436" r="56" gradientTransform="matrix(1.3372 .35831 -.35834 1.3373 -60.034 -112.8)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#40494c" offset="0"/>
+      <stop stop-color="#232829" offset=".57201"/>
+      <stop offset="1"/>
+    </radialGradient>
+    <linearGradient id="linearGradient1095" x1="99.846" x2="431.14" y1="91.301" y2="91.301" gradientTransform="translate(-246.02 -371.38)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f6d32d" offset="0"/>
+      <stop stop-color="#f9f06b" offset="1"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient2619">
-      <stop
-         style="stop-color:#c4a000;stop-opacity:1"
-         offset="0"
-         id="stop2615" />
-      <stop
-         style="stop-color:#edd400;stop-opacity:0"
-         offset="1"
-         id="stop2617" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient1171">
-      <stop
-         id="stop1165"
-         offset="0"
-         style="stop-color:#40494c;stop-opacity:1" />
-      <stop
-         style="stop-color:#232829;stop-opacity:1"
-         offset="0.57201189"
-         id="stop1167" />
-      <stop
-         id="stop1169"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:1" />
-    </linearGradient>
-    <radialGradient
-       r="160"
-       fy="16.275131"
-       fx="280"
-       cy="16.275131"
-       cx="280"
-       gradientTransform="matrix(1,0,0,1.1758925,0,-118.6378)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient1073"
-       xlink:href="#linearGradient2619" />
-    <radialGradient
-       r="56"
-       fy="65.435539"
-       fx="265.28162"
-       cy="65.435539"
-       cx="265.28162"
-       gradientTransform="matrix(1.3372396,0.35831226,-0.35833822,1.3373363,-60.03431,-112.79804)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient1075"
-       xlink:href="#linearGradient1171" />
-    <linearGradient
-       gradientTransform="translate(-246.01698,-371.37682)"
-       gradientUnits="userSpaceOnUse"
-       y2="91.300674"
-       x2="431.13885"
-       y1="91.300674"
-       x1="99.845581"
-       id="linearGradient1095"
-       xlink:href="#linearGradient1093" />
   </defs>
-  <metadata
-     id="metadata4">
+  <metadata>
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
         <dc:creator>
           <cc:Agent>
             <dc:title>GNOME Design Team</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:source />
-        <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:source/>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/"/>
         <dc:title>Adwaita Icon Template</dc:title>
         <dc:subject>
-          <rdf:Bag />
+          <rdf:Bag/>
         </dc:subject>
-        <dc:date />
+        <dc:date/>
         <dc:rights>
           <cc:Agent>
-            <dc:title />
+            <dc:title/>
           </cc:Agent>
         </dc:rights>
         <dc:publisher>
           <cc:Agent>
-            <dc:title />
+            <dc:title/>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier />
-        <dc:relation />
-        <dc:language />
-        <dc:coverage />
-        <dc:description />
+        <dc:identifier/>
+        <dc:relation/>
+        <dc:language/>
+        <dc:coverage/>
+        <dc:description/>
         <dc:contributor>
           <cc:Agent>
-            <dc:title />
+            <dc:title/>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#Notice" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#Attribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      <cc:License rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+        <cc:requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+        <cc:requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+        <cc:requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0,-172)"
-     style="display:inline"
-     id="layer1">
-    <g
-       style="display:inline"
-       id="layer9">
-      <rect
-         ry="8"
-         rx="8"
-         y="184"
-         x="12.000001"
-         height="104"
-         width="104"
-         id="rect15122"
-         style="display:inline;opacity:1;vector-effect:none;fill:#5e5c64;fill-opacity:1;stroke:none;stroke-width:0.01200435px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-      <circle
-         r="60"
-         cy="236"
-         cx="64"
-         id="path15129"
-         style="display:inline;opacity:1;vector-effect:none;fill:#5e5c64;fill-opacity:1;stroke:none;stroke-width:0.01200435px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-      <g
-         id="g1061"
-         transform="matrix(0.26562505,0,0,0.26562505,-10.395244,230.82553)"
-         style="display:inline;enable-background:new">
-        <g
-           transform="rotate(-30,413.50258,270.491)"
-           id="g1045" />
-        <ellipse
-           ry="195.77086"
-           rx="195.76466"
-           cy="19.474165"
-           cx="280.07614"
-           id="ellipse1049"
-           style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.04607898px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-        <ellipse
-           style="display:inline;opacity:1;vector-effect:none;fill:#2a2a3b;fill-opacity:1;stroke:none;stroke-width:0.04591639px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
-           id="ellipse1051"
-           cx="280.07614"
-           cy="19.47464"
-           rx="180.70584"
-           ry="180.71156" />
-        <ellipse
-           transform="rotate(90)"
-           ry="165.65254"
-           rx="165.64664"
-           cy="-280.07614"
-           cx="19.475237"
-           id="ellipse1053"
-           style="display:inline;opacity:1;vector-effect:none;fill:url(#linearGradient1095);fill-opacity:1;stroke:none;stroke-width:0.04678777px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-        <circle
-           cy="20.005707"
-           cx="280"
-           id="circle1055"
-           style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient1073);fill-opacity:1;stroke:none;stroke-width:0.04519285px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
-           r="0" />
-        <ellipse
-           ry="75.299042"
-           rx="75.294106"
-           cy="19.475416"
-           cx="280.07617"
-           id="ellipse1057"
-           style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.04726049px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-        <ellipse
-           transform="rotate(-15)"
-           ry="60.239342"
-           rx="60.234993"
-           cy="91.305618"
-           cx="265.49091"
-           id="ellipse1059"
-           style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient1075);fill-opacity:1;stroke:none;stroke-width:0.04861055px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+  <g transform="translate(0,-172)">
+    <g>
+      <rect x="12" y="184" width="104" height="104" rx="8" ry="8" enable-background="new" fill="#5e5c64" style="paint-order:normal"/>
+      <circle cx="64" cy="236" r="60" enable-background="new" fill="#5e5c64" style="paint-order:normal"/>
+      <g transform="matrix(.26563 0 0 .26563 -10.395 230.83)" enable-background="new">
+        <ellipse cx="280.08" cy="19.474" rx="195.76" ry="195.77" enable-background="new" style="paint-order:normal"/>
+        <ellipse cx="280.08" cy="19.475" rx="180.71" ry="180.71" enable-background="new" fill="#2a2a3b" style="paint-order:normal"/>
+        <ellipse transform="rotate(90)" cx="19.475" cy="-280.08" rx="165.65" ry="165.65" enable-background="new" fill="url(#linearGradient1095)" style="paint-order:normal"/>
+        <circle cx="280" cy="20.006" r="0" enable-background="new" fill="url(#radialGradient1073)" style="paint-order:normal"/>
+        <ellipse cx="280.08" cy="19.475" rx="75.294" ry="75.299" enable-background="new" style="paint-order:normal"/>
+        <ellipse transform="rotate(-15)" cx="265.49" cy="91.306" rx="60.235" ry="60.239" enable-background="new" fill="url(#radialGradient1075)" style="paint-order:normal"/>
       </g>
-      <path
-         d="m 24.000056,278 a 1.9999996,2.0364742 0 0 1 -2,2.03648 1.9999996,2.0364742 0 0 1 -2,-2.03648 1.9999996,2.0364742 0 0 1 2,-2.03647 1.9999996,2.0364742 0 0 1 2,2.03647 z m 84.000004,0 a 1.9999996,2.0364742 0 0 1 -2,2.03648 1.9999996,2.0364742 0 0 1 -2,-2.03648 1.9999996,2.0364742 0 0 1 2,-2.03647 1.9999996,2.0364742 0 0 1 2,2.03647 z m 0,-84.00001 a 1.9999996,2.0364742 0 0 1 -2,2.03648 1.9999996,2.0364742 0 0 1 -2,-2.03648 1.9999996,2.0364742 0 0 1 2,-2.03647 1.9999996,2.0364742 0 0 1 2,2.03647 z m -84.000004,0 a 1.9999996,2.0364742 0 0 1 -2,2.03648 1.9999996,2.0364742 0 0 1 -2,-2.03648 1.9999996,2.0364742 0 0 1 2,-2.03647 1.9999996,2.0364742 0 0 1 2,2.03647 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.00896273px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
-         id="path1116-3" />
+      <path d="m24 278a2 2.0365 0 0 1-2 2.0365 2 2.0365 0 0 1-2-2.0365 2 2.0365 0 0 1 2-2.0365 2 2.0365 0 0 1 2 2.0365zm84 0a2 2.0365 0 0 1-2 2.0365 2 2.0365 0 0 1-2-2.0365 2 2.0365 0 0 1 2-2.0365 2 2.0365 0 0 1 2 2.0365zm0-84a2 2.0365 0 0 1-2 2.0365 2 2.0365 0 0 1-2-2.0365 2 2.0365 0 0 1 2-2.0365 2 2.0365 0 0 1 2 2.0365zm-84 0a2 2.0365 0 0 1-2 2.0365 2 2.0365 0 0 1-2-2.0365 2 2.0365 0 0 1 2-2.0365 2 2.0365 0 0 1 2 2.0365z" enable-background="new" style="paint-order:normal"/>
     </g>
   </g>
 </svg>

--- a/data/icons/hicolor/symbolic/apps/org.gnome.Music-symbolic.svg
+++ b/data/icons/hicolor/symbolic/apps/org.gnome.Music-symbolic.svg
@@ -1,28 +1,22 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='gnome-music-symbolic.svg' height='16.000021' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.5 r10040' version='1.1' width='16.000002' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <metadata>
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
         <dc:title>Gnome Symbolic Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer9' inkscape:cx='-20.161588' inkscape:cy='0.43776036' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#555753' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1375' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='8'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-142px' originy='-341.99998px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
-  </sodipodi:namedview>
-  <title id='title9167'>Gnome Symbolic Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='layer9' inkscape:label='apps' style='display:inline' transform='translate(-383.0002,125)'>
-    
-    <path inkscape:connector-curvature='0' d='m 391.0002,-125 c -4.40643,0 -8,3.59357 -8,8 0,4.40643 3.59357,8 8,8 4.40643,0 8,-3.59357 8,-8 0,-4.40643 -3.59357,-8 -8,-8 z m 0,2 c 3.32555,0 6,2.67445 6,6 0,3.32555 -2.67445,6 -6,6 -3.32555,0 -6,-2.67445 -6,-6 0,-3.32555 2.67445,-6 6,-6 z' id='path3869' style='font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans'/>
-    <path sodipodi:cx='1.2423376' sodipodi:cy='1.3786418' d='m 2.0387079,1.3786418 a 0.79637027,0.79637027 0 1 1 -1.59274058,0 0.79637027,0.79637027 0 1 1 1.59274058,0 z' id='path9013' sodipodi:rx='0.79637027' sodipodi:ry='0.79637027' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate' transform='matrix(1.883546,0,0,1.883546,382.1602,-126.09672)' sodipodi:type='arc'/>
-    <path sodipodi:cx='1.2423376' sodipodi:cy='1.3786418' d='m 2.0387079,1.3786418 a 0.79637027,0.79637027 0 1 1 -1.59274058,0 0.79637027,0.79637027 0 1 1 1.59274058,0 z' id='path9013-9' sodipodi:rx='0.79637027' sodipodi:ry='0.79637027' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate' transform='matrix(1.8835459,0,0,1.8835459,395.1602,-126.09672)' sodipodi:type='arc'/>
-    <path sodipodi:cx='1.2423376' sodipodi:cy='1.3786418' d='m 2.0387079,1.3786418 a 0.79637027,0.79637027 0 1 1 -1.59274058,0 0.79637027,0.79637027 0 1 1 1.59274058,0 z' id='path9013-5' sodipodi:rx='0.79637027' sodipodi:ry='0.79637027' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate' transform='matrix(1.8835459,0,0,1.8835459,382.1602,-113.09671)' sodipodi:type='arc'/>
-    <path sodipodi:cx='1.2423376' sodipodi:cy='1.3786418' d='m 2.0387079,1.3786418 a 0.79637027,0.79637027 0 1 1 -1.59274058,0 0.79637027,0.79637027 0 1 1 1.59274058,0 z' id='path9013-9-1' sodipodi:rx='0.79637027' sodipodi:ry='0.79637027' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate' transform='matrix(1.883546,0,0,1.883546,395.1602,-113.09671)' sodipodi:type='arc'/>
-    <path sodipodi:cx='1.2423376' sodipodi:cy='1.3786418' d='m 2.0387079,1.3786418 a 0.79637027,0.79637027 0 1 1 -1.59274058,0 0.79637027,0.79637027 0 1 1 1.59274058,0 z' id='path9013-7' sodipodi:rx='0.79637027' sodipodi:ry='0.79637027' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate' transform='matrix(3.7670919,0,0,3.7670919,386.3202,-122.19345)' sodipodi:type='arc'/>
+  <title>Gnome Symbolic Icon Theme</title>
+  <g transform="translate(-383 125)" fill="#bebebe">
+    <path d="m391-125c-4.4064 0-8 3.5936-8 8s3.5936 8 8 8 8-3.5936 8-8-3.5936-8-8-8zm0 2c3.3256 0 6 2.6744 6 6s-2.6744 6-6 6-6-2.6744-6-6 2.6744-6 6-6z" color="#000000" style="block-progression:tb;text-indent:0;text-transform:none"/>
+    <path transform="matrix(1.8835 0 0 1.8835 382.16 -126.1)" d="m2.0387 1.3786a0.79637 0.79637 0 1 1-1.5927 0 0.79637 0.79637 0 1 1 1.5927 0z" color="#000000"/>
+    <path transform="matrix(1.8835 0 0 1.8835 395.16 -126.1)" d="m2.0387 1.3786a0.79637 0.79637 0 1 1-1.5927 0 0.79637 0.79637 0 1 1 1.5927 0z" color="#000000"/>
+    <path transform="matrix(1.8835 0 0 1.8835 382.16 -113.1)" d="m2.0387 1.3786a0.79637 0.79637 0 1 1-1.5927 0 0.79637 0.79637 0 1 1 1.5927 0z" color="#000000"/>
+    <path transform="matrix(1.8835 0 0 1.8835 395.16 -113.1)" d="m2.0387 1.3786a0.79637 0.79637 0 1 1-1.5927 0 0.79637 0.79637 0 1 1 1.5927 0z" color="#000000"/>
+    <path transform="matrix(3.7671 0 0 3.7671 386.32 -122.19)" d="m2.0387 1.3786a0.79637 0.79637 0 1 1-1.5927 0 0.79637 0.79637 0 1 1 1.5927 0z" color="#000000"/>
   </g>
 </svg>


### PR DESCRIPTION
Ran Inkscape's built-in optimizer and cleaned up SVG files for main and symbolic icons. Inkscape normally saves SVG with lot of extra data while optimizers keep only the necessary ones without affecting the actual image itself. Optimized SVGs are smaller in size and faster to render. This is the command I ran:

    for file in *.svg; do scour -i "$file" -o "$file"opt --set-precision=5 --renderer-workaround --enable-viewboxing --indent=space --nindent=2 --strip-xml-space --enable-id-stripping --protect-ids-noninkscape; mv -- "$file"opt "$file"; done